### PR TITLE
Hiding non-Konar Slayer Masters on Milestones

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ Reminds you to use Konar for more points at milestone slayer tasks
 
 Reminds you before every 10th, 50th, 100th, 250th, 1000th, or nth task to go to konar for your next one
 
-Optionally highlight/mark other slayer masters as an additional reminder.
+Optionally highlight/mark or hide other slayer masters as an additional reminder.
 
 To update, check your task with a slayer helm/gem or complete a task.

--- a/src/main/java/com/konarreminder/KonarReminderConfig.java
+++ b/src/main/java/com/konarreminder/KonarReminderConfig.java
@@ -10,9 +10,9 @@ public interface KonarReminderConfig extends Config
 	String CONFIG_GROUP = "konarreminder";
 	String TASK_UNIT = " tasks";
 	@ConfigItem(
-		keyName = "multiple",
-		name = "Milestone Reminder",
-		description = "Sets the task multiple/milestone to activate the reminder before"
+			keyName = "multiple",
+			name = "Milestone Reminder",
+			description = "Sets the task multiple/milestone to activate the reminder before"
 	)
 	@Units(KonarReminderConfig.TASK_UNIT)
 	default int multiple()
@@ -21,9 +21,9 @@ public interface KonarReminderConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "chatMessageColor",
-		name = "Chat Message Color",
-		description = "The chat message reminder to use Konar will be this color."
+			keyName = "chatMessageColor",
+			name = "Chat Message Color",
+			description = "The chat message reminder to use Konar will be this color."
 	)
 	default Color chatMessageColor()
 	{
@@ -38,11 +38,23 @@ public interface KonarReminderConfig extends Config
 	String renderStyleSection = "renderStyleSection";
 
 	@ConfigItem(
+			keyName = "hideOtherSlayerMasters",
+			name = "Hide non-Konar on reminder",
+			description = "Configures whether or not other slayer masters should be hidden when you should go to konar",
+			section = renderStyleSection,
+			position = -2
+	)
+	default boolean hideOtherSlayerMasters()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 			keyName = "otherHighlight",
 			name = "Highlight non-Konar on reminder",
 			description = "Configures whether or not other slayer masters should be highlighted when you should go to konar",
 			section = renderStyleSection,
-			position = -2
+			position = -1
 	)
 	default boolean otherHighlight()
 	{

--- a/src/main/java/com/konarreminder/KonarReminderPlugin.java
+++ b/src/main/java/com/konarreminder/KonarReminderPlugin.java
@@ -91,12 +91,14 @@ public class KonarReminderPlugin extends Plugin
 	protected void startUp() throws Exception
 	{
 		npcOverlayService.registerHighlighter(isHighlighted);
+		hooks.registerRenderableDrawListener(drawListener);
+
+		updateConfig();
+
 		clientThread.invoke(() ->
 		{
 			rebuild();
 		});
-
-		hooks.registerRenderableDrawListener(drawListener);
 
 		log.info("Konar Milestone Reminder started!");
 	}
@@ -105,12 +107,12 @@ public class KonarReminderPlugin extends Plugin
 	protected void shutDown() throws Exception
 	{
 		npcOverlayService.unregisterHighlighter(isHighlighted);
+		hooks.unregisterRenderableDrawListener(drawListener);
+
 		clientThread.invoke(() ->
 		{
 			highlightedNpcs.clear();
 		});
-
-		hooks.unregisterRenderableDrawListener(drawListener);
 
 		log.info("Konar Milestone Reminder stopped!");
 	}
@@ -342,6 +344,7 @@ public class KonarReminderPlugin extends Plugin
 				} else {
 					config.setReminderStatus(false);
 				}
+				updateConfig();
 				rebuild();
 			}
 		}
@@ -360,7 +363,7 @@ public class KonarReminderPlugin extends Plugin
 		{
 			NPC npc = (NPC) renderable;
 
-			if (highlightMatchesNPCName(npc.getName()))
+			if (highlightMatchesNPCName(npc.getName()) && config.getReminderStatus())
 			{
 				return !hideOtherSlayerMasters;
 			}


### PR DESCRIPTION
I added the ability to hide non-Konar Slayer Masters on task milestones. This makes the player unable to get a new task from any slayer master other than Konar (Just in case they didn't pay attention to the chat message). If hide and highlight are both selected it will outline the hidden NPC but also makes them untargetable.